### PR TITLE
Fix shapely, scipy deprecated functions

### DIFF
--- a/modules/environments/environments/office.py
+++ b/modules/environments/environments/office.py
@@ -133,7 +133,7 @@ def add_walls(grid, wall_fill_val=L_BKD, space_val=L_HALL):
     kernel = np.ones([3, 3])
 
     free_grid_mask = grid == space_val
-    inflated_mask = scipy.ndimage.filters.convolve(
+    inflated_mask = scipy.ndimage.convolve(
         free_grid_mask, kernel, mode="constant", cval=0
     )
 

--- a/modules/environments/environments/pickle_loader.py
+++ b/modules/environments/environments/pickle_loader.py
@@ -28,10 +28,10 @@ def _inflate_grid_label(grid, inflation_radius, label_val):
     kernel = np.zeros((kernel_size, kernel_size))
     kernel[y * y + x * x <= inflation_radius * inflation_radius] = 1
 
-    inflated_mask = scipy.ndimage.filters.convolve(flattened_grid,
-                                                   kernel,
-                                                   mode='constant',
-                                                   cval=0)
+    inflated_mask = scipy.ndimage.convolve(flattened_grid,
+                                           kernel,
+                                           mode='constant',
+                                           cval=0)
     return inflated_mask
 
 

--- a/modules/gridmap/gridmap/utils.py
+++ b/modules/gridmap/gridmap/utils.py
@@ -38,10 +38,10 @@ def inflate_grid(grid,
     y, x = np.ogrid[-cind:kernel_size - cind, -cind:kernel_size - cind]
     kernel = np.zeros((kernel_size, kernel_size))
     kernel[y * y + x * x <= inflation_radius * inflation_radius] = 1
-    inflated_mask = scipy.ndimage.filters.convolve(obstacle_grid,
-                                                   kernel,
-                                                   mode='constant',
-                                                   cval=0)
+    inflated_mask = scipy.ndimage.convolve(obstacle_grid,
+                                           kernel,
+                                           mode='constant',
+                                           cval=0)
     inflated_mask = inflated_mask >= 1.0
     inflated_grid = grid.copy()
     inflated_grid[inflated_mask] = collision_val


### PR DESCRIPTION
Fixed features:
- Fix unsupported features in `shapely`
- Change deprecated `scipy.ndimage.filters.convolve` to `scipy.ndimage.convolve`

Without these changes, the tests for the `environments` module failed in the main branch.