### PR TITLE
Add ProcTHOR caching and generate smooth robot trajectories

### DIFF
--- a/modules/object_search/object_search/utils.py
+++ b/modules/object_search/object_search/utils.py
@@ -4,7 +4,7 @@ from common import Pose
 import lsp
 
 
-def compute_cost_and_trajectory(grid, path, resolution=0.05, use_robot_model=True):
+def compute_cost_and_trajectory(grid, path, resolution=0.05, use_robot_model=False):
     '''This function returns the path cost, robot trajectory
     given the occupancy grid and the container poses the
     robot explored during object search.
@@ -71,7 +71,7 @@ def compute_cost_and_robot_trajectory(grid, path):
                                                                 do_use_path=True)
             robot.move(motion_primitives, np.argmin(costs))
             dist = Pose.cartesian_distance(robot.pose, next_pose)
-            if dist < 1.0:
+            if dist <= 2.0:
                 reached = True
 
     trajectory = [[], []]

--- a/modules/object_search/object_search/utils.py
+++ b/modules/object_search/object_search/utils.py
@@ -1,12 +1,23 @@
 import numpy as np
 import gridmap
+from common import Pose
+import lsp
 
 
-def compute_cost_and_trajectory(grid, path):
+def compute_cost_and_trajectory(grid, path, resolution=0.05, use_robot_model=True):
     '''This function returns the path cost, robot trajectory
     given the occupancy grid and the container poses the
     robot explored during object search.
     '''
+    if use_robot_model:
+        cost, trajectory = compute_cost_and_robot_trajectory(grid, path)
+    else:
+        cost, trajectory = compute_cost_and_dijkstra_trajectory(grid, path)
+
+    return resolution * cost, trajectory
+
+
+def compute_cost_and_dijkstra_trajectory(grid, path):
     total_cost = 0
     trajectory = None
     occ_grid = np.copy(grid)
@@ -34,3 +45,38 @@ def compute_cost_and_trajectory(grid, path):
             trajectory = np.concatenate((trajectory, robot_path), axis=1)
 
     return total_cost, trajectory
+
+
+def compute_cost_and_robot_trajectory(grid, path):
+    robot = lsp.robot.Turtlebot_Robot(pose=Pose(path[0].x, path[0].y, yaw=0))
+
+    for _, next_pose in enumerate(path[1:]):
+        cost_grid, get_path = gridmap.planning.compute_cost_grid_from_position(
+            grid, start=[next_pose.x, next_pose.y],
+            use_soft_cost=True,
+            only_return_cost_grid=False
+        )
+
+        reached = False
+        while not reached:
+            _, robot_path = get_path([robot.pose.x, robot.pose.y],
+                                     do_sparsify=True,
+                                     do_flip=True)
+            motion_primitives = robot.get_motion_primitives()
+            costs, _ = lsp.primitive.get_motion_primitive_costs(grid,
+                                                                cost_grid,
+                                                                robot.pose,
+                                                                robot_path,
+                                                                motion_primitives,
+                                                                do_use_path=True)
+            robot.move(motion_primitives, np.argmin(costs))
+            dist = Pose.cartesian_distance(robot.pose, next_pose)
+            if dist < 1.0:
+                reached = True
+
+    trajectory = [[], []]
+    for pose in robot.all_poses:
+        trajectory[0].append(pose.x)
+        trajectory[1].append(pose.y)
+
+    return robot.net_motion, np.array(trajectory)

--- a/modules/object_search/tests/test_object_search_navigation.py
+++ b/modules/object_search/tests/test_object_search_navigation.py
@@ -11,7 +11,7 @@ def get_args():
     args.save_dir = '/data/test_logs'
     args.current_seed = 0
     args.resolution = 0.05
-    args.do_save_video = True
+    args.do_save_video = False
     return args
 
 
@@ -41,7 +41,8 @@ def test_object_search_optimistic_planner():
         chosen_subgoal = planner.compute_selected_subgoal()
         planning_loop.set_chosen_subgoal(chosen_subgoal)
 
-    cost, trajectory = object_search.utils.compute_cost_and_trajectory(known_grid, robot.all_poses)
+    cost, trajectory = object_search.utils.compute_cost_and_trajectory(known_grid, robot.all_poses, args.resolution,
+                                                                       use_robot_model=True)
 
     plt.figure(figsize=(8, 8))
     known_locations = [known_graph.get_node_name_by_idx(idx) for idx in target_obj_info['container_idxs']]
@@ -66,7 +67,7 @@ def test_object_search_optimistic_planner():
     plt.subplot(224)
     ax = plt.subplot(224)
     object_search.plotting.plot_grid_with_robot_trajectory(ax, known_grid, robot.all_poses, trajectory, known_graph)
-    plt.title(f"Cost: {cost:0.3f}")
+    plt.title(f"Cost: {cost:0.1f} meters")
 
     plt.savefig(Path(args.save_dir) / f'object_search_optimistic_{args.current_seed}.png', dpi=1000)
 


### PR DESCRIPTION
This is small PR that includes the following:
- Implement caching of ProcTHOR data so that the need to instantiate `Controller` class (which is launches the AI2THOR simulator) can be alleviated if there is a cache. Cache is saved on first run of every seed and is reused on subsequent runs.
- For object search, add option to generate smooth robot trajectories (using existing `Turtlebot_Robot` class).
- Compute robot navigation costs in meters when computing trajectories.

Trajectory comparison:
Grid-based:
<img width="429" height="326" alt="image" src="https://github.com/user-attachments/assets/c364e9b1-337b-4d7a-8a66-4d4d59743840" />
Smooth:
<img width="429" height="326" alt="image" src="https://github.com/user-attachments/assets/8ca2e454-4dfd-40f4-a610-65b1f91fa0bc" />
