### PR TITLE
Fix for the gnn

### DIFF
--- a/modules/sctp/Makefile.mk
+++ b/modules/sctp/Makefile.mk
@@ -104,6 +104,13 @@ sctp-results:
 		--save_dir data/$(SCTP_BASENAME)/$(SCTP_EXPERIMENT_NAME)/ \
 		--num_drones $(SCTP_NUM_DRONES) \
 
+
+.PHONY: iapgnn-train
+iapgnn-train:
+	@echo "Training IAP-GNN"
+	@$(DOCKER_PYTHON) -m sctp.scripts.iapgnn_training
+
+
 # .PHONY: mr-task-vis-net-predictions
 # mr-task-vis-net-predictions: DOCKER_ARGS ?= -it
 # mr-task-vis-net-predictions:

--- a/modules/sctp/sctp/learning/iap_gnn.py
+++ b/modules/sctp/sctp/learning/iap_gnn.py
@@ -80,7 +80,7 @@ class BipartiteEdgeRegressor(nn.Module):
         # Node u connects to Edge e, Node v connects to Edge e.
 
         # Source indices (Nodes)
-        node_idx_all = edge_index.flatten() # [Source_0, Target_0, Source_1, Target_1...]
+        node_idx_all = edge_index.t().contiguous().view(-1) # [Source_0, Target_0, Source_1, Target_1...]
 
         # Target indices (Edges)
         # We repeat each edge index twice: [Edge_0, Edge_0, Edge_1, Edge_1...]

--- a/modules/sctp/sctp/scripts/__init__.py
+++ b/modules/sctp/sctp/scripts/__init__.py
@@ -1,8 +1,8 @@
-from . import sctp_eval_bridge_graph_old
-from . import jsap_eval_island_graph
-from . import sctp_dec_eval_random_graph
-from . import sctp_results
-from . import dsapPrior_eval_bridges_graph
-from . import jsap_eval_bridges_graph
-from . import data_gen
-from . import iapgnn_training
+# from . import sctp_eval_bridge_graph_old
+# from . import jsap_eval_island_graph
+# from . import sctp_dec_eval_random_graph
+# from . import sctp_results
+# from . import dsapPrior_eval_bridges_graph
+# from . import jsap_eval_bridges_graph
+# from . import data_gen
+# from . import iapgnn_training

--- a/modules/sctp/sctp/scripts/iapgnn_training.py
+++ b/modules/sctp/sctp/scripts/iapgnn_training.py
@@ -13,7 +13,7 @@ from torch_geometric.data import Data
 class GzipGNNDataset(Dataset):
     def __init__(self, folder_path):
         self.file_paths = glob.glob(os.path.join(folder_path, '*.pgz'))
-        
+
     def __len__(self):
         return len(self.file_paths)
 
@@ -30,37 +30,37 @@ class GzipGNNDataset(Dataset):
         if hasattr(raw_data, 'graph_metadata'):
             data.metadata = raw_data.graph_metadata
         return data
-        
+
 
 
 def train_epoch(model, loader, optimizer, criterion, device):
     model.train()
     total_loss = 0
-    
+
     for batch in loader:
         batch = batch.to(device)
         optimizer.zero_grad()
-        
+
         # 2. Forward Pass
         # Pass the batch data and the specific node attributes
         output = model(
-            x= batch.x, 
+            x= batch.x,
             edge_index=batch.edge_index,
             edge_attr=batch.edge_attr,
         )
-        
+
         # 3. Compute Loss
         # Ensure output and target have the same shape [Batch, 1]
         # loss = criterion(output.view(-1), batch.y.view(-1))
         loss = criterion(output, batch.y)  # MSE Loss between predicted and true edge values
-        
+
         # 4. Backward Pass
         loss.backward()
         optimizer.step()
-        
+
         # total_loss += loss.item() * batch.num_graphs
         total_loss += loss.item()
-        
+
     return total_loss / len(loader)
 
 
@@ -74,18 +74,18 @@ if __name__ == "__main__":
     train_loader = DataLoader(dataset, batch_size=8, shuffle=True)
 
     # 1. Setup Device & Model
-    # device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    device = torch.device('cpu')  # Force CPU for debugging
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    # device = torch.device('cpu')  # Force CPU for debugging
     NODE_IN = 2
     EDGE_IN = 2
     HIDDEN = 32
     model = BipartiteEdgeRegressor(node_in_dim=NODE_IN, edge_in_dim=EDGE_IN, hidden_dim=HIDDEN).to(device)
-    optimizer = optim.Adam(model.parameters(), lr=0.001)
+    optimizer = optim.Adam(model.parameters(), lr=0.0001)
     criterion = nn.MSELoss()
-    
+
     # 5. Execute Training
-    num_epochs = 50
+    num_epochs = 500
     for epoch in range(1, num_epochs + 1):
         loss = train_epoch(model, train_loader, optimizer, criterion, device)
-        if epoch % 10 == 0:
-            print(f'Epoch: {epoch:03d}, MSE Loss: {loss:.4f}')
+        # if epoch % 10 == 0:
+        print(f'Epoch: {epoch:03d}, MSE Loss: {loss:.4f}')

--- a/modules/sctp/sctp/scripts/iapgnn_training.py
+++ b/modules/sctp/sctp/scripts/iapgnn_training.py
@@ -23,7 +23,7 @@ class GzipGNNDataset(Dataset):
             raw_data = pickle.load(f)
         data = Data(
             x=torch.from_numpy(raw_data.x).float(),
-            edge_index=torch.from_numpy(raw_data.edge_index).long(),
+            edge_index=torch.from_numpy(raw_data.edge_index).long().t().contiguous(),
             edge_attr=torch.from_numpy(raw_data.edge_attr).float(),
             y=torch.from_numpy(raw_data.y).float(),
         )

--- a/modules/sctp/tests/test_iapgnn_learning.py
+++ b/modules/sctp/tests/test_iapgnn_learning.py
@@ -76,11 +76,8 @@ def test_IAPtraining():
     device = torch.device('cpu')  # Force CPU for debugging
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     criterion = nn.MSELoss()
-    
+
     num_epochs = 1
     for epoch in range(1, num_epochs+1):
         loss = train_epoch(model, train_loader, optimizer, criterion, device)
-        print(f"Epoch {epoch+1}/{num_epochs}, Loss: {loss:.4f}")
-    
-    
-    
+        print(f"Epoch {epoch}/{num_epochs}, Loss: {loss:.4f}")


### PR DESCRIPTION
Fix on gnn edge index shape.
Here's what was happening:

- `PyTorch Geometric` expects the `edge_index` to be of shape `[2, num_edges]`, but your raw data saved it as `[num_edges, 2]`. This was causing `DataLoader` to concatenate the batches along `dim=0` incorrectly instead of `dim=1`.
- To fix this, I updated `GzipGNNDataset.__getitem__` in `iapgnn_training.py` to transpose `edge_index` properly: `edge_index.t().contiguous()`.
- In `iap_gnn.py`, the `edge_index.flatten()` call assumed that the indices for the start and end nodes of an edge were adjacent. However, since the matrix is now correctly `[2, num_edges]`, `flatten()` would group all start nodes together and all end nodes together. I changed it to `edge_index.t().contiguous().view(-1)` so that the nodes and edges correctly pair up for the bipartite graph GAT layer.